### PR TITLE
Fix ancestor.nucleus variable. It was filled when the track got track…

### DIFF
--- a/include/NumiTrackInformation.hh
+++ b/include/NumiTrackInformation.hh
@@ -37,6 +37,11 @@ class NumiTrackInformation : public G4VUserTrackInformation
     {return Nimpwt;}
     inline void SetNImpWt(G4double nimpweight)
     {Nimpwt=nimpweight;}
+
+    inline G4int GetPDGNucleus() const 
+    {return fPDGNucleus;}
+    inline void SetPDGNucleus(G4int PDGnucleus)
+    {fPDGNucleus=PDGnucleus;}
     
     void Print() const;
 
@@ -54,6 +59,7 @@ private:
     G4int              decay_code;
     G4int              tgen;
     G4double           Nimpwt;
+    G4int              fPDGNucleus; //used to fill ancestor.nucleus
     G4ThreeVector      fParentMomentumAtThisProduction;
 
 };

--- a/src/NumiStackingAction.cc
+++ b/src/NumiStackingAction.cc
@@ -9,9 +9,11 @@
 #include "G4Event.hh"
 #include "G4HCofThisEvent.hh"
 #include "G4Track.hh"
+#include "G4Nucleus.hh"
 #include "G4TrackStatus.hh"
 #include "G4ParticleDefinition.hh"
 #include "G4ParticleTypes.hh"
+#include "G4HadronicProcess.hh"
 #include "G4ios.hh"
 #include "NumiImpWeight.hh"
 #include "NumiTrackInformation.hh"
@@ -47,7 +49,7 @@ G4ClassificationOfNewTrack NumiStackingAction::ClassifyNewTrack(const G4Track * 
    
   G4ClassificationOfNewTrack classification = fUrgent;
   G4ParticleDefinition * particleType = aTrack->GetDefinition();
-
+  
   if(NumiData->GetDebugLevel() > 2)
   {
      G4int evtno = pRunManager->GetCurrentEvent()->GetEventID();
@@ -154,6 +156,17 @@ G4ClassificationOfNewTrack NumiStackingAction::ClassifyNewTrack(const G4Track * 
            classification = fKill;
         }
      }
+  }
+
+  auto hadronicProcess =
+    dynamic_cast<const G4HadronicProcess*>( aTrack->GetCreatorProcess() );
+
+  if ( classification != fKill && hadronicProcess ) {
+    G4Nucleus nucleus = *(hadronicProcess->GetTargetNucleus());
+    G4int fPDGNucleus = 1000000000 +
+      nucleus.GetZ_asInt()*10000 + nucleus.GetA_asInt()*10;    
+    NumiTrackInformation* trackInfo=(NumiTrackInformation*)(aTrack->GetUserInformation());  
+    if (trackInfo!=0) trackInfo->SetPDGNucleus(fPDGNucleus);
   }
   
   return classification;

--- a/src/NumiTrackInformation.cc
+++ b/src/NumiTrackInformation.cc
@@ -11,7 +11,8 @@ G4Allocator<NumiTrackInformation> aTrackInformationAllocator;
 NumiTrackInformation::NumiTrackInformation()
   :decay_code(0),
    tgen(0),
-   Nimpwt(1.0)
+   Nimpwt(1.0),
+   fPDGNucleus(0)
 {
 
 }
@@ -22,6 +23,7 @@ NumiTrackInformation::NumiTrackInformation(const NumiTrackInformation* aTrackInf
   decay_code = aTrackInfo->decay_code;
   tgen = aTrackInfo->tgen;
   Nimpwt = aTrackInfo->Nimpwt;
+  fPDGNucleus = aTrackInfo->fPDGNucleus;
 }
 
 NumiTrackInformation::~NumiTrackInformation(){}
@@ -34,6 +36,8 @@ void NumiTrackInformation::Print() const
      << "tgen = " << tgen << G4endl;
     G4cout 
      << "nimpwt = " << Nimpwt << G4endl;
+    G4cout 
+     << "nucleus = " << fPDGNucleus << G4endl;
 }
 
 void NumiTrackInformation::Print(const G4Track *aTrack) const

--- a/src/NumiTrajectory.cc
+++ b/src/NumiTrajectory.cc
@@ -129,10 +129,17 @@ NumiTrajectory::NumiTrajectory(const G4Track* aTrack)
        dynamic_cast<const G4HadronicProcess*>( aTrack->GetCreatorProcess() );
 
      if ( hadronicProcess ) {
+       /* getting nucleus at this point is not necessarily getting the one associated with this track
+	  this gets the nucleus associate with the last time this hadronicProcess was used.
+	  So instead will store this info in NumiTrackInfo within NumiStackingAction and then retrieve here 
+      
        G4Nucleus nucleus = *(hadronicProcess->GetTargetNucleus());
        fPDGNucleus = 1000000000 +
          nucleus.GetZ_asInt()*10000 + nucleus.GetA_asInt()*10;
-
+       */
+       NumiTrackInformation* trackInfo=(NumiTrackInformation*)(aTrack->GetUserInformation());  
+       if (trackInfo) fPDGNucleus = trackInfo->GetPDGNucleus();
+       
        // flag it as EM process with negative isotope code
        if ( fProcessName == "muonNuclear"     ||
             fProcessName == "electronNuclear" ||


### PR DESCRIPTION
…ed at which point the hadronicProcess was no longer necessarily pointing to the correct nucleus. Other tracks from the stack that have been tracked before the current track could invoke the same hadronicProcess and change the nucleus pointer.