### PR TITLE
Woodtp/main modern g4

### DIFF
--- a/ProcessG4NuMI_localprod.py
+++ b/ProcessG4NuMI_localprod.py
@@ -40,8 +40,8 @@ DO_HORN1_NEW_GEOMETRY = True
 
 BEAM_POSITION_X       = 0      #m
 BEAM_POSITION_Y       = 0      #m
-BEAM_SPOTSIZE_X       = 1.4    #mm (ME!)
-BEAM_SPOTSIZE_Y       = 1.4    #mm (ME!)
+BEAM_SPOTSIZE_X       = 1.5    #mm (ME!)
+BEAM_SPOTSIZE_Y       = 1.5    #mm (ME!)
 
 TARGET_POSITION_X     = 0.0    #cm
 TARGET_POSITION_Y     = 0.0    #cm

--- a/g4numi_job_localprod.sh
+++ b/g4numi_job_localprod.sh
@@ -36,9 +36,11 @@ setup g4numi $version -q $qualifier
 
 echo
 echo "======== UPDATE MACRO WITH RUN NUMBER ========"
-SEED=$(date +%Y%m%d%H%M%S)
+DATE=$(date +%Y%m%d%H%M%S)
+MAX_LONG=2147483647  # Random number generator accepts a long.
+SEED=$(( PROCESS + $(date +%s%3N) % MAX_LONG ))
 sed -i 's/\${seed}/'$SEED'/g' g4numi.mac
-OUTFILE="g4numi${G4NUMIVER}_${PLAYLIST}_${BEAMCONFIG}_${PROCESS}_${SEED}"
+OUTFILE="g4numi${G4NUMIVER}_${PLAYLIST}_${BEAMCONFIG}_${PROCESS}_${SEED}_${DATE}"
 sed -i 's/\${outfile}/'$OUTFILE'/g' g4numi.mac
 
 echo "BEAMCONFIG=${BEAMCONFIG}"


### PR DESCRIPTION
1. Default the beam spot size to 1.5 mm.
2. Fix the bug I introduced where the random seed would overflow resulting in the seed being set to the max long.